### PR TITLE
feat: confirmWinner

### DIFF
--- a/contracts/MonoNFT.sol
+++ b/contracts/MonoNFT.sol
@@ -14,6 +14,7 @@ contract MonoNFT is ERC4907, IMonoNFT, AccessControl {
     address public auctionDepositContractAddress;
 
     mapping(uint256 => monoNFT) public _monoNFTs;
+    mapping(uint256 => Winner) public _latestWinners;
 
     constructor(
         string memory _name,
@@ -37,11 +38,24 @@ contract MonoNFT is ERC4907, IMonoNFT, AccessControl {
         address winner,
         uint256 tokenId,
         uint256 price,
-        uint64 expires
+        uint256 expires
+    ) public onlyRole(DEFAULT_ADMIN_ROLE) {
+        // TODO: Check whether the winner has the auction member NFT
+        _monoNFTs[tokenId].status = MonoNFTStatus.CONFIRMED;
+        _latestWinners[tokenId] = Winner(winner, price, expires);
+        emit ConfirmWinner(tokenId, winner, price);
+    }
+
+    // In principle, expires should be calculated using expiresDuration,
+    // but it can also be specified externally for flexibility.
+    function confirmWinner(
+        address winner,
+        uint256 tokenId,
+        uint256 price
     ) external onlyRole(DEFAULT_ADMIN_ROLE) {
         // TODO: Check whether the winner has the auction member NFT
-        // TODO: CONFIRMEDに変更
-        // TODO: 落札情報を登録
+        uint256 expires = block.number + _monoNFTs[tokenId].expiresDuration;
+        confirmWinner(winner, tokenId, price, expires);
     }
 
     function submit(uint256 tokenId) external onlyRole(DEFAULT_ADMIN_ROLE) {

--- a/contracts/interfaces/IMonoNFT.sol
+++ b/contracts/interfaces/IMonoNFT.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.18;
+pragma solidity ^0.8.18;
 
 import "./IERC4907.sol";
 
@@ -28,6 +28,16 @@ interface IMonoNFT is IERC4907 {
         uint64 expiresDuration;
         string uri;
         MonoNFTStatus status;
+    }
+
+    // The struct of Winner
+    /// @param winner: オークションの落札者, Winner of an auction
+    /// @param price: オークションの落札価格, The price of an auction
+    /// @param expires:expires: 利用権の有効期限, The expires of the user
+    struct Winner {
+        address winner;
+        uint256 price;
+        uint256 expires;
     }
 
     // Emit when a winner of an auction is confirmed.
@@ -61,7 +71,7 @@ interface IMonoNFT is IERC4907 {
         address winner,
         uint256 tokenId,
         uint256 price,
-        uint64 expires
+        uint256 expires
     ) external;
 
     // Submit a monoNFT for auction

--- a/test/monoNFT.ts
+++ b/test/monoNFT.ts
@@ -3,7 +3,7 @@ import {
   AuctionDeposit,
   IMonoNFT,
   MockERC20,
-  MonoNFT,
+  MonoNFT
 } from '../typechain-types'
 import { ethers } from 'hardhat'
 import { parseEther } from 'ethers'
@@ -27,19 +27,19 @@ describe('MonoNFT', () => {
     tokenContract = await ethers.deployContract('MockERC20', [
       'My Token',
       'MTK',
-      initialSupply,
+      initialSupply
     ])
     await tokenContract.waitForDeployment()
 
     auctionDepositContract = await ethers.deployContract('AuctionDeposit', [
-      await tokenContract.getAddress(),
+      await tokenContract.getAddress()
     ])
     await auctionDepositContract.waitForDeployment()
 
     monoNFTContract = await ethers.deployContract('MonoNFT', [
       'monoNFT',
       'mono',
-      await auctionDepositContract.getAddress(),
+      await auctionDepositContract.getAddress()
     ])
     await monoNFTContract.waitForDeployment()
   })
@@ -77,7 +77,7 @@ describe('MonoNFT', () => {
       //半年
       expiresDuration: (1000 * 60 * 60 * 24 * 365) / 2,
       uri: 'https://metadata.uri',
-      status: 0,
+      status: 0
     }
 
     expect(
@@ -95,5 +95,60 @@ describe('MonoNFT', () => {
     )
     expect(monoNFTs[0].uri).to.equal(monoNFTMetadata.uri)
     expect(monoNFTs[0].status).to.equal(monoNFTMetadata.status)
+  })
+
+  describe('confirmWinner', () => {
+    let latestBlock
+
+    beforeEach(async () => {
+      const monoNFTMetadata: IMonoNFT.MonoNFTStruct = {
+        donor: user1.address,
+        //半年
+        expiresDuration: (1000 * 60 * 60 * 24 * 365) / 2,
+        uri: 'https://metadata.uri',
+        status: 0
+      }
+      await monoNFTContract.connect(admin).register(monoNFTMetadata)
+      latestBlock = await ethers.provider.getBlock('latest')
+    })
+
+    it('should confirmWinner without duration', async () => {
+      expect(
+        await monoNFTContract
+          .connect(admin)
+          ['confirmWinner(address,uint256,uint256)'](
+            user1.address,
+            1,
+            parseEther('1000')
+          )
+      ).to.emit(monoNFTContract, 'ConfirmWinner')
+
+      const _latestWinners = await monoNFTContract._latestWinners(1)
+      expect(_latestWinners.winner).to.equal(user1.address)
+      expect(_latestWinners.price).to.equal(parseEther('1000'))
+      expect(_latestWinners.expires).to.equal(
+        latestBlock!.number + 1 + (1000 * 60 * 60 * 24 * 365) / 2
+      )
+    })
+
+    it('should confirmWinner with duration', async () => {
+      expect(
+        await monoNFTContract
+          .connect(admin)
+          ['confirmWinner(address,uint256,uint256,uint256)'](
+            user1.address,
+            1,
+            parseEther('500'),
+            latestBlock!.timestamp + 1000 * 60 * 60 * 24 * 365
+          )
+      ).to.emit(monoNFTContract, 'ConfirmWinner')
+
+      const _latestWinners = await monoNFTContract._latestWinners(1)
+      expect(_latestWinners.winner).to.equal(user1.address)
+      expect(_latestWinners.price).to.equal(parseEther('500'))
+      expect(_latestWinners.expires).to.equal(
+        latestBlock!.timestamp + 1000 * 60 * 60 * 24 * 365
+      )
+    })
   })
 })


### PR DESCRIPTION
- claim 時に支払金額が必要になると思い struct を追加しています
- expire については考え方が様々あると思うのですが…外部から注入できる＆原則expireDurationを使う記述があり、関数名を増やさないようにするとoverloadが必要になりました
  - 外部から注入する際は期日を直接指定できたほうがいいと考え uint64 から uint256 に変更していますが、指摘があれば修正可能です
