### PR TITLE
feat: isEligible

### DIFF
--- a/contracts/interfaces/IMonoNFT.sol
+++ b/contracts/interfaces/IMonoNFT.sol
@@ -87,6 +87,16 @@ interface IMonoNFT is IERC4907, IAccessControl {
         address _auctionDepositContractAddress
     ) external;
 
+    // Get the total number of monoNFTs of an user
+    /// @param user: ユーザーアドレス, The address of the user
+    /// @return ユーザーが落札しているmonoNFTの数, The total number of monoNFTs of an user
+    function confirmedMonosOf(address user) external view returns (uint256);
+
+    // Get the max number of monoNFTs of an user
+    /// @param user: ユーザーアドレス, The address of the user
+    /// @return ユーザーが落札できるmonoNFTの最大数, The max number of monoNFTs of an user
+    function maxConfirmedMonosOf(address user) external view returns (uint256);
+
     // Admin register a monoNFT
     /// @param donor: monoの寄贈者, Donor of the mono
     /// @param expiresDuration: monoNFTのデフォルトの利用権保有期間, Default expires duration of the monoNFT

--- a/test/deposit.ts
+++ b/test/deposit.ts
@@ -5,7 +5,7 @@ import {
   AuctionDeposit,
   MockERC20,
   MonoNFT,
-  MockERC1155,
+  MockERC1155
 } from '../typechain-types'
 import { formatEther, parseEther } from 'ethers'
 
@@ -26,7 +26,7 @@ describe('AuctionDeposit', function () {
     tokenContract = await ethers.deployContract('MockERC20', [
       'My Token',
       'MTK',
-      initialSupply,
+      initialSupply
     ])
     await tokenContract.waitForDeployment()
     await tokenContract
@@ -41,11 +41,14 @@ describe('AuctionDeposit', function () {
     monoNFTContract = await ethers.deployContract('MonoNFT', [
       'monoNFT',
       'mono',
+      1,
+      2,
+      3
     ])
     await monoNFTContract.waitForDeployment()
 
     auctionDepositContract = await ethers.deployContract('AuctionDeposit', [
-      await monoNFTContract.getAddress(),
+      await monoNFTContract.getAddress()
     ])
     await auctionDepositContract.waitForDeployment()
 

--- a/test/withdraw.ts
+++ b/test/withdraw.ts
@@ -6,7 +6,7 @@ import {
   MockERC20,
   MaliciousAttacker,
   MonoNFT,
-  MockERC1155,
+  MockERC1155
 } from '../typechain-types'
 import { formatEther, parseEther } from 'ethers'
 
@@ -28,7 +28,7 @@ describe('AuctionWithdraw', function () {
     tokenContract = await ethers.deployContract('MockERC20', [
       'My Token',
       'MTK',
-      initialSupply,
+      initialSupply
     ])
     await tokenContract.waitForDeployment()
 
@@ -47,12 +47,15 @@ describe('AuctionWithdraw', function () {
     monoNFTContract = await ethers.deployContract('MonoNFT', [
       'monoNFT',
       'mono',
+      1,
+      2,
+      3
     ])
     await monoNFTContract.waitForDeployment()
 
     // AuctionDepositのデプロイ
     auctionDepositContract = await ethers.deployContract('AuctionDeposit', [
-      await monoNFTContract.getAddress(),
+      await monoNFTContract.getAddress()
     ])
     await auctionDepositContract.waitForDeployment()
 


### PR DESCRIPTION
`isEligible` を実装しました！

```solidity
modifier isEligible(address user) {
    uint256 confirmedMonosOfUser = confirmedMonosOf(user);
    uint256 maxConfirmedMonosOfUser = maxConfirmedMonosOf(user);
    require(
        confirmedMonosOfUser < maxConfirmedMonosOfUser,
        "MonoNFT: Insufficient membership"
    );
    _;
}
```
としていて、 `confirmedMonosOf()` では `confirmWinner()` で `_latestWinner` に記録された落札者と使用期限を参照して、ユーザーの現在の落札数を計算しています。

これは、落札数ではなく Claim された後の状態で制限した場合、落札だけして Claim しなければ何個でも落札できるのではないかと思ったため、こんな感じにしてみました！

そのため、 `claim()` にも `isEligible` modifier をつけてしまうと実行できなくなるので（落札数は既に+1されているため）、あえて付けない形にしてみました。

close #26 